### PR TITLE
Fix #3: Use format specifiers instead of string concatenation

### DIFF
--- a/jabgui/src/main/java/org/jabref/cli/ArgumentProcessor.java
+++ b/jabgui/src/main/java/org/jabref/cli/ArgumentProcessor.java
@@ -45,13 +45,13 @@ public class ArgumentProcessor {
         guiNeeded = true;
 
         if ((startupMode == Mode.INITIAL_START) && cli.isVersionHelpRequested()) {
-            System.out.printf(BuildInfo.JABREF_BANNER + "%n", new BuildInfo().version);
+            System.out.printf("%s%n", BuildInfo.JABREF_BANNER + new BuildInfo().version);
             guiNeeded = false;
             return List.of();
         }
 
         if ((startupMode == Mode.INITIAL_START) && cli.isUsageHelpRequested()) {
-            System.out.printf(BuildInfo.JABREF_BANNER + "%n", new BuildInfo().version);
+            System.out.printf("%s%n", BuildInfo.JABREF_BANNER + new BuildInfo().version);
             System.out.println(cli.getUsageMessage());
 
             guiNeeded = false;


### PR DESCRIPTION
This PR fixes a technical debt issue reported by SonarCloud.

Issue:
Format specifiers should be used instead of string concatenation.

File affected:
src/main/java/org/jabref/cli/ArgumentProcessor.java

Fix:
Replaced string concatenation with proper format specifier usage to improve maintainability and comply with SonarCloud rule java:S3457.

Closes #3 